### PR TITLE
CH6 rules hotfix: BoB + evidence cap enforcement

### DIFF
--- a/Patches/ROOT_SEC-06-07_World_UI_CH5-CH6_Merge.md
+++ b/Patches/ROOT_SEC-06-07_World_UI_CH5-CH6_Merge.md
@@ -22,3 +22,19 @@
 
 ## Notes
 - Keep all text period-accurate to 1994. No modern tech terms.
+
+## CH6 Raid ROE and Safety
+
+- CH6 = raid. Lethal authorized. Neutralizations are score-neutral.  
+- **Blue-on-Blue = hard fail (−10).** Exceptions: (1) Shield-absorbed friendly hits do not count. (2) A **single** shotgun pellet striking a friendly **>10 m** away does not count.  
+- Cameras only in Service Passage; **No CCTV in Vault**. Breaker cut ≈90 s. **K-9 reroute** available.  
+- **Evidence cap = 3** in CH6. HUD must show `Evidence 0/3` and a `BlueOnBlue` indicator.
+
+## CH6 Raid ROE and Safety
+
+- CH6 = raid. Lethal authorized. Neutralizations are score-neutral.
+- Blue-on-Blue = hard fail (-10). Exceptions:
+  (1) Shield-absorbed friendly hits do not count.
+  (2) A single shotgun pellet striking a friendly >10 m away does not count.
+- Cameras only in Service Passage; No CCTV in Vault. Breaker cut approx 90 s. K-9 reroute available.
+- Evidence cap = 3 in CH6. HUD must show "Evidence 0/3" and a "BlueOnBlue" indicator.

--- a/Patches/ROOT_Systems_Snippet_Replacements.md
+++ b/Patches/ROOT_Systems_Snippet_Replacements.md
@@ -27,3 +27,25 @@ No smartphone/Wi-Fi/Bluetooth/GPS/SMS. Use landlines, pagers, fax, film, Polaroi
 
 [SNIP-SEC05-HUD]
 HUD must include: Evidence 0/3, BlueOnBlue flag, Cast L, Cast R, Equip L, Equip R. Prompts ≤14 characters.
+
+### SEC-05 • CH6 Evidence Cap + Blue-on-Blue Guards
+
+```pseudo
+if Chapter == 6:
+  EVIDENCE_CAP = 3
+
+  onEvidenceInteract(item):
+    if EvidenceCount >= EVIDENCE_CAP:
+      HUD.flash("Evidence 3/3")
+      disableInteract(item)
+      return
+    EvidenceCount += 1
+    HUD.setEvidence(EvidenceCount, EVIDENCE_CAP)
+
+  # Blue-on-Blue hard fail with exceptions
+  onHit(event):
+    if isFriendly(event.target):
+      if event.absorbed_by_shield: return
+      if event.weapon == "shotgun" and event.pellets_hit == 1 and event.distance_m > 10: return
+      failMission(reason="Blue-on-Blue", penalty=-10)
+      HUD.flag("BlueOnBlue")


### PR DESCRIPTION
Add CH6 ROE text; enforce evidence cap with Blue-on-Blue exceptions; extend grep coverage.