### PR TITLE
archive: add chat exports (2025-08-16)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,14 +1,11 @@
-# Chapter 2 Packaging
+Adds exported chat archives to /Archive for provenance and repo retention.
 
-Adds CH2 patch and state tracker, aligned with the narrative outline.
+Files:
+- Archive/GDD_Rebuild_2025-08-16_0809.md
+- Archive/GDD_Rebuild_2025-08-16_1347.md
+- Archive/GDD_Rebuild_2025-08-16_1700.md
 
-## Files
-- `Patches/CH2.md`
-- `Trackers/CH2-state.md`
-
-## Notes
-- Clara: survival, stealth, and analog Rolodex rescue mechanic. Must keep Reddy’s stat lines balanced for points.
-- Avery: promoted with Level X clearance, meets Lewis Krill, tempted toward lethal methods. Player choice impacts alignment.
-- Score thresholds remain TBD for balancing.
-- 1994 tech fidelity enforced (Rolodex, payphone, fax, pager).
-
+Checklist:
+- [ ] Verify archive filenames and frontmatter
+- [ ] Confirm no sensitive data included
+- [ ] Tag commit after merge: archive-2025-08-16


### PR DESCRIPTION
Adds exported chat archives for provenance and project history.

Summary
- Exports of archived project chats saved to /Archive for retention and repo traceability.
- Provides provenance for recent repo decisions and PRs referenced in those chats.

Files
- Archive/GDD_Rebuild_2025-08-16_0809.md
- Archive/GDD_Rebuild_2025-08-16_1347.md
- Archive/GDD_Rebuild_2025-08-16_1700.md

Checklist for reviewer
- [ ] Verify filenames and frontmatter timestamps are correct.
- [ ] Confirm no sensitive or PII data included in any file.
- [ ] Confirm markdown renders (preview) and transcript content matches expected chat text.
- [ ] Approve and merge. Tag merge commit: `archive-2025-08-16`.

Post-merge actions (owner)
- Run a quick grep for sensitive tokens: `git grep -nE "password|token|secret|ssn|credit" Archive || true`
- Tag the merge: `git tag archive-2025-08-16 && git push origin archive-2025-08-16`
- Close related housekeeping tasks in Trackers/Archive-Kickoff.md

Notes
- These files are documentation only. No CI required.
