### PR TITLE
ci(local-ui): add backend tests and frontend build

### DIFF
--- a/.github/workflows/local-ui.yml
+++ b/.github/workflows/local-ui.yml
@@ -1,0 +1,30 @@
+﻿name: local-ui
+on:
+  pull_request: { branches: [ main ] }
+  push: { branches: [ main ] }
+jobs:
+  backend:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r tools/local-ui/backend/requirements.txt
+          python -m pip install pytest httpx
+      - name: Run tests
+        env: { PYTHONPATH: tools/local-ui }
+        run: python -m pytest tools/local-ui/backend/tests -q
+  frontend:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "lts/*" }
+      - name: Build
+        working-directory: tools/local-ui/frontend
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## Summary
Add GitHub Actions to run FastAPI tests (Py 3.12) and Vite build (Node LTS).
Also appends a Windows Quickstart to README.

## Jobs
- backend: pip install, `PYTHONPATH=tools/local-ui` pytest
- frontend: Node LTS, `npm ci && npm run build`

## Notes
Consumes Actions minutes. Safe to merge when checks pass.

Closes #62.
