### PR TITLE
ci: add workflow_dispatch to workflows where safe (TS-MAC-0036)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,7 @@
 name: dependabot-auto-merge
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,7 @@
 name: dependency-review
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,5 +1,6 @@
 ﻿name: Issue Labeler
 on:
+  workflow_dispatch:
   issues:
     types: [opened, edited]
 permissions:

--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -1,6 +1,7 @@
 ﻿name: mkdocs-build
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/pr_assistant.yml
+++ b/.github/workflows/pr_assistant.yml
@@ -1,6 +1,7 @@
 ﻿name: PR Assistant
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,6 +1,7 @@
 ﻿name: PR Labeler
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 

--- a/ops/reports/workflow_dispatch_report_ops/macro-manager-workflow-dispatch-20250821104914.md
+++ b/ops/reports/workflow_dispatch_report_ops/macro-manager-workflow-dispatch-20250821104914.md
@@ -1,0 +1,5 @@
+# workflow_dispatch enablement report
+
+- patched_files: 6
+- manual_files:
+  - .github/workflows/epilogue-validate.yml


### PR DESCRIPTION
## Summary
- add manual trigger to dependabot, dependency-review, issue labeler, mkdocs build, PR assistant, and PR labeler workflows
- document pending manual follow-up for epilogue-validate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f951ef84832db56f8af6a82af3a2