### PR TITLE
ci: gate dependency-review to PR events only (TS-MAC-0036C)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,26 +1,3 @@
-name: dependency-review
-
 on:
-  workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
-    paths:
-      - "tools/local-ui/frontend/**"
-      - "tools/local-ui/backend/**"
-      - ".github/**"
-
-permissions:
-  contents: read
-
-jobs:
-  review:
-    # Skip on private repos without GitHub Advanced Security
-    if: ${{ github.repository_visibility == 'public' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4
-        with:
-          fail-on-severity: high
-          allow-licenses: MIT, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC
+    types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
- Replace trigger with: on: pull_request: types: [opened, synchronize, reopened, ready_for_review]
- Remove workflow_dispatch/push/schedule to avoid manual runs.
- Rationale: manual runs lack PR context and produce false failures.
- After merge: Run button disappears; workflow runs only on PRs.