### PR TITLE
TS-MAC-0036C

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,16 @@
+name: dependency-review
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4


### PR DESCRIPTION
ci: restore dependency-review job; keep PR-only trigger (TS-MAC-0036C)