### PR TITLE
chore(ops): add daily Rollover Stamp workflow

### DIFF
--- a/.github/workflows/rollover-stamp.yml
+++ b/.github/workflows/rollover-stamp.yml
@@ -1,0 +1,17 @@
+name: Rollover Stamp
+on:
+  schedule:
+    - cron: "7 7 * * *"   # 07:07 UTC daily
+  workflow_dispatch: {}
+jobs:
+  stamp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate stamp
+        run: |
+          date -u +%Y-%m-%dT%H:%M:%SZ > stamp.txt
+          echo "repo=Goldmanvision/Diplomagic_GDD" >> stamp.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rollover-stamp
+          path: stamp.txt


### PR DESCRIPTION
## Summary
- add daily workflow that uploads timestamped artifact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a937110690832dbbf2c66f2773c2c2