### PR TITLE
test(daps): add JSON route smoke test and wire into CI

### DIFF
--- a/.github/workflows/daps-ci.yml
+++ b/.github/workflows/daps-ci.yml
@@ -1,0 +1,14 @@
+name: daps-ci
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  smoke-routes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Smoke route tests
+        run: node ops/tests/smoke-routes.mjs

--- a/ops/tests/smoke-routes.mjs
+++ b/ops/tests/smoke-routes.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs';
+const candidates = ['daps/routes.json'];
+const manifest = candidates.find(p => fs.existsSync(p));
+if (!manifest) {
+  console.log('SMOKE: SKIP no routes manifest (expected daps/routes.json)');
+  process.exit(0);
+}
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+} catch (e) {
+  console.error(`SMOKE: FAIL unable to parse ${manifest}: ${e.message}`);
+  process.exit(1);
+}
+const routes = Array.isArray(data) ? data : (Array.isArray(data.routes) ? data.routes : []);
+if (!Array.isArray(routes) || routes.length === 0) {
+  console.log('SMOKE: SKIP routes empty');
+  process.exit(0);
+}
+let bad = 0; const seen = new Set();
+for (const r of routes) {
+  const path = typeof r === 'string' ? r : (r && typeof r.path === 'string' ? r.path : '');
+  if (!path || !path.startsWith('/') || /\s/.test(path)) { console.error(`SMOKE: BAD path ${JSON.stringify(path)}`); bad++; }
+  if (seen.has(path)) { console.error(`SMOKE: DUP path ${path}`); bad++; }
+  seen.add(path);
+}
+if (bad) { console.error(`SMOKE: FAIL ${bad} issues`); process.exit(1); }
+console.log(`SMOKE: PASS ${routes.length} routes`);
+process.exit(0);


### PR DESCRIPTION
## Summary
- add JSON smoke test for daps/routes.json
- run smoke test in daps CI workflow

## Testing
- `node ops/tests/smoke-routes.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a949500a04832d99bfc4d840d0add5