### PR TITLE
ci(daps): harden CI (concurrency cancel, permissions, timeout)

### DIFF
--- a/.github/workflows/daps-ci.yml
+++ b/.github/workflows/daps-ci.yml
@@ -2,9 +2,18 @@ name: daps-ci
 on:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daps-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke-routes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- cancel redundant PR runs via workflow concurrency
- restrict permissions to contents: read
- add a 10-minute job timeout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a95519e14c832dbfd1f6a80fe18c32