### PR TITLE
Add httpx to backend requirements

### DIFF
--- a/tools/local-ui/backend/requirements.txt
+++ b/tools/local-ui/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 python-multipart
 jsonschema
 pathspec
+httpx


### PR DESCRIPTION
## Summary
- include httpx in local UI backend requirements

## Testing
- `pip install -r tools/local-ui/backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68aab47e8630832d986feecbfb254b20