### PR TITLE
Add job cards for Windows DAPS client development

### DIFF
--- a/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0004.md
+++ b/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0004.md
@@ -1,0 +1,26 @@
+# Job Card TS-MAC-DAPS-0004 — JC-WIN-01: Windows DAPS client scaffold
+
+**Owner:** diplomagic-codex-agent
+**Labels:** ops, windows, daps
+**Branch:** ops/win-client-01-scaffold
+**Goal:** Scaffold a Windows DAPS client with pluggable model interfaces.
+
+## Tasks
+- Choose Electron or .NET MAUI for `clients/windows/`; justify choice in README.
+- Set up project skeleton and wiring for build scripts and CI.
+- Implement configuration and secure OpenAI key storage (Windows credential vault or equivalent; no secrets in repo).
+- Define service-layer interfaces for OpenAI and local Ollama with mock adapters.
+- Add minimal GUI: prompt input box and transcript pane.
+- Document install/build/run steps in README.
+
+## Acceptance
+- Build runs locally on Windows.
+- GUI can hit mock OpenAI/Ollama adapters (no real calls).
+- README includes framework rationale and run instructions.
+
+## Notes
+- Use PR template (scope, screenshots, run steps).
+- Run lint and unit tests; attach zipped artifact.
+- Keep changes under `clients/windows/**` plus CI files.
+- Reuse existing Prompt Hub visuals when possible.
+- Tag `win-client-v0.1` after all WIN job cards merge.

--- a/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0005.md
+++ b/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0005.md
@@ -1,0 +1,24 @@
+# Job Card TS-MAC-DAPS-0005 — JC-WIN-02: Chat-history persistence & repo sync
+
+**Owner:** diplomagic-codex-agent
+**Labels:** ops, windows, daps, history
+**Branch:** ops/win-client-02-history-sync
+**Goal:** Persist chat transcripts and synchronize with repository handoff files.
+**Prerequisite:** JC-WIN-01 scaffold layout.
+
+## Tasks
+- Define JSON or Markdown transcript schema under `clients/windows/`.
+- Implement import/export logic to read and write `handoff/` folder files.
+- Establish merge policy for concurrent updates (app vs repo).
+- Add unit tests covering round-trip and merge scenarios.
+
+## Acceptance
+- App round-trips transcripts between GUI and `handoff/` without data loss.
+- Merge policy preserves all messages.
+- Tests pass in CI.
+
+## Notes
+- Use PR template (scope, screenshots, run steps).
+- Run lint and unit tests; attach zipped artifact.
+- Keep changes under `clients/windows/**` plus CI files.
+- Reuse Prompt Hub visuals where feasible.

--- a/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0006.md
+++ b/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0006.md
@@ -1,0 +1,24 @@
+# Job Card TS-MAC-DAPS-0006 — JC-WIN-03: Context API for Workthreads
+
+**Owner:** diplomagic-codex-agent
+**Labels:** ops, windows, daps, context
+**Branch:** ops/win-client-03-context-api
+**Goal:** Expose API for Workthreads to push and retrieve context for prompts.
+**Prerequisite:** JC-WIN-01 scaffold layout.
+
+## Tasks
+- Provide local HTTP endpoint or file-watch API for context ingestion.
+- Require auth token for pushes.
+- Add settings toggle to retain or clear history per session.
+- Supply example script demonstrating context push.
+
+## Acceptance
+- Example script pushes context successfully.
+- Client injects last N messages into prompt before dispatch.
+- History toggle works as configured.
+
+## Notes
+- Use PR template (scope, screenshots, run steps).
+- Run lint and unit tests; attach zipped artifact.
+- Keep changes under `clients/windows/**` plus CI files.
+- Reuse Prompt Hub visuals where feasible.

--- a/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0007.md
+++ b/ops/tech_support/macro-manager/job_cards/job_card_TS-MAC-DAPS-0007.md
@@ -1,0 +1,25 @@
+# Job Card TS-MAC-DAPS-0007 — JC-WIN-04: Dynamic model routing (OpenAI ↔ Ollama)
+
+**Owner:** diplomagic-codex-agent
+**Labels:** ops, windows, daps, routing
+**Branch:** ops/win-client-04-routing
+**Goal:** Enable runtime model selection and fallback between OpenAI and local Ollama.
+**Prerequisite:** JC-WIN-01 scaffold layout and adapter interfaces.
+
+## Tasks
+- Add settings UI to choose backend and model.
+- Implement adapters for OpenAI REST API and local Ollama service.
+- Provide fallback rules and user-facing error surfaces when a backend is unavailable.
+- Support runtime switching between backends without restarting.
+
+## Acceptance
+- User can switch backends at runtime.
+- Client continues with degraded operation if one backend is down.
+- Errors are surfaced to the UI.
+
+## Notes
+- Use PR template (scope, screenshots, run steps).
+- Run lint and unit tests; attach zipped artifact.
+- Keep changes under `clients/windows/**` plus CI files.
+- Reuse Prompt Hub visuals where feasible.
+- Tag `win-client-v0.1` after all WIN job cards merge.


### PR DESCRIPTION
## Summary
- add JC-WIN-01 job card to scaffold Windows DAPS client with mock OpenAI/Ollama adapters
- add JC-WIN-02 job card outlining chat-history persistence and repo sync
- add JC-WIN-03 job card defining context API for Workthreads
- add JC-WIN-04 job card for dynamic model routing between OpenAI and Ollama

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aac4627c4c832db723f187591c14b5