### PR TITLE
fix: quote run-name in ops runner dispatch workflow

### DIFF
--- a/.github/workflows/ops-runner-dispatch.yml
+++ b/.github/workflows/ops-runner-dispatch.yml
@@ -1,5 +1,5 @@
 name: ops-runner-dispatch
-run-name: ops-runner: ${{ inputs.op }} on ${{ inputs.target_ref }}
+run-name: "ops-runner: ${{ inputs.op }} on ${{ inputs.target_ref }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- quote `run-name` in ops-runner dispatch workflow to resolve YAML parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aada778548832dacd5c41c2bc82982