### PR TITLE
test(local-ui): skip backend tests without fastapi

### DIFF
--- a/tools/local-ui/README.md
+++ b/tools/local-ui/README.md
@@ -28,4 +28,12 @@ tools\local-ui\run_backend.bat    # starts 127.0.0.1:5174
 - Outbox JSONL at `tools/local-ui/_outbox/outbox.jsonl` via `/outbox` and `/outbox/tail`.
 - Feed keeps last 200 entries.
 
+## Tests
+```bash
+# from repo root
+python -m pip install -r tools/local-ui/backend/requirements-dev.txt
+python -m pytest tools/local-ui/backend/tests
+```
+The API tests require `fastapi` and will be skipped automatically if it is not installed.
+
 CI tick: 2025-08-24T15:54:35


### PR DESCRIPTION
## Summary
- skip local-ui FastAPI tests when FastAPI isn't installed
- document backend test steps and FastAPI requirement

## Testing
- `python -m pytest -q`
- `./scripts/test.sh >/tmp/test.log && cat /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab918a0ae8832db56b61471b60c864