### PR TITLE
ci(local-ui): allow skip via tag or label

### DIFF
--- a/.github/workflows/local-ui-pack.yml
+++ b/.github/workflows/local-ui-pack.yml
@@ -1,1 +1,31 @@
-﻿<PASTE-YAML-HERE>
+name: local-ui-pack
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+jobs:
+  build:
+    if: >
+      !(
+        (github.event.head_commit && contains(github.event.head_commit.message, '[skip local-ui]')) ||
+        (github.event.pull_request && contains(join(github.event.pull_request.labels.*.name, ','), 'skip-local-ui'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - name: pip deps (backend)
+        run: python -m pip install -U -r tools/local-ui/backend/requirements.txt
+      - name: zip pack
+        run: |
+          mkdir -p dist
+          zip -r dist/prompt-hub-v0.3.zip \
+            tools/local-ui/backend \
+            tools/local-ui/frontend \
+            tools/local-ui/run_backend.bat \
+            tools/local-ui/run_backend.ps1 \
+            tools/local-ui/.env.example \
+            tools/local-ui/README.md
+      - uses: actions/upload-artifact@v4
+        with: { name: prompt-hub-v0.3, path: dist/prompt-hub-v0.3.zip }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ This repo favors small, reviewable PRs. Even if `main` is temporarily unprotecte
 - Include a short rationale and validation notes.
 - CI must be green before merge (when enabled).
 - Squash or merge-commit; stay consistent per release cycle.
+- To skip the local UI pack workflow, include `[skip local-ui]` in a commit message or add a `skip-local-ui` label to the PR.
 
 ## Line Endings
 On Windows, Git may warn about CRLF. This repo enforces LF via `.gitattributes`. Do **not** change editor defaults; Git will normalize on commit.


### PR DESCRIPTION
## Summary
- allow local UI pack workflow to skip when commit uses `[skip local-ui]` or PR labeled `skip-local-ui`
- document local UI skip instructions in contributing guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab91892b68832da3cd2ab149206b59