### PR TITLE
Add context service tests

### DIFF
--- a/clients/windows/rag/context_service.py
+++ b/clients/windows/rag/context_service.py
@@ -1,0 +1,36 @@
+"""Simple context lookup service for embedded logs."""
+
+from __future__ import annotations
+
+import array
+import sqlite3
+from pathlib import Path
+from typing import List
+
+from .embed_logs import DB_FILE, compute_embedding, DEFAULT_DB_DIR
+
+
+def _vector_from_blob(blob: bytes) -> list[float]:
+    arr = array.array("f")
+    arr.frombytes(blob)
+    return list(arr)
+
+
+def query(text: str, db_dir: Path = DEFAULT_DB_DIR, top_k: int = 1) -> List[str]:
+    """Return up to *top_k* snippets most similar to *text*."""
+    db_path = Path(db_dir) / DB_FILE
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT text, vector FROM embeddings").fetchall()
+    conn.close()
+    if not rows:
+        return []
+    target = compute_embedding(text)
+    scored = []
+    for row_text, blob in rows:
+        vec = _vector_from_blob(blob)
+        dist = sum((a - b) ** 2 for a, b in zip(target, vec))
+        scored.append((dist, row_text))
+    scored.sort(key=lambda x: x[0])
+    return [text for _, text in scored[:top_k]]

--- a/clients/windows/rag/tests/test_context_service.py
+++ b/clients/windows/rag/tests/test_context_service.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+# Ensure repository root on path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from clients.windows.rag import embed_logs, context_service
+
+
+def test_context_service_returns_relevant_snippet(tmp_path, monkeypatch):
+    log_dir = tmp_path / "ops/handoffs/logs"
+    db_dir = tmp_path / "ops/handoffs"
+    log_dir.mkdir(parents=True)
+
+    log_file = log_dir / "sample.log"
+    log_file.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    # Ensure external embedding command is stubbed
+    monkeypatch.setattr(embed_logs.subprocess, "run", lambda *a, **k: None)
+
+    embed_logs.main(log_dir=log_dir, db_dir=db_dir)
+
+    results = context_service.query("beta", db_dir=db_dir, top_k=1)
+    assert results == ["beta"]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,9 +4,16 @@ if [ -f tools/local-ui/frontend/package.json ]; then
   if [ -x tools/local-ui/frontend/node_modules/.bin/vitest ]; then
     (cd tools/local-ui/frontend && npm test || tools/local-ui/frontend/node_modules/.bin/vitest run || true)
   else
-    echo "[tests] frontend present but vitest not installed; sandbox skip"; exit 0
+    echo "[tests] frontend present but vitest not installed; sandbox skip"
   fi
 else
   echo "[tests] lock status"; python3 ops/locks/scripts/lock_status.py || true
+fi
+
+if command -v pytest >/dev/null 2>&1; then
+  echo "[tests] python"
+  pytest
+else
+  echo "[tests] pytest not installed; skipping python tests"
 fi
 echo "[tests] done"


### PR DESCRIPTION
## Summary
- Add context lookup module for log embeddings
- Test context retrieval after running embed_logs
- Update watch log error tests and run pytest from npm test script

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab96859338832d93aea125110d51a9