### PR TITLE
feat: add Windows RAG CLI and PowerShell helpers

### DIFF
--- a/clients/windows/rag/README.md
+++ b/clients/windows/rag/README.md
@@ -15,8 +15,30 @@ If you see `ModuleNotFoundError: watchdog` when running `watch_logs.py`, it
 means the optional `watchdog` package is missing. Install the dependencies as
 shown above.
 
-## Scripts
+## CLI
 
-- `embed_logs.py` – embed existing transcripts.
-- `watch_logs.py` – monitor the log directory and stream new lines into the
-  transcript and vector index.
+The tools can be invoked through the package itself:
+
+```bash
+python -m clients.windows.rag embed            # Embed existing logs
+python -m clients.windows.rag watch            # Start log watcher
+python -m clients.windows.rag query "text"     # Retrieve similar lines
+```
+
+Use `--log-dir` and `--db-dir` to override the default paths (`ops/handoffs/logs`
+and `ops/handoffs`).
+
+## PowerShell helpers
+
+For Windows users the following scripts simplify setup and execution:
+
+- `install-deps.ps1` – create a virtual environment and install dependencies.
+- `run-pipeline.ps1` – embed any existing logs then start the watcher.
+
+Run them from PowerShell using `./install-deps.ps1` and `./run-pipeline.ps1`.
+
+## Troubleshooting
+
+- Include `[skip local-ui]` in a commit message to bypass the local UI workflow.
+- Ensure `watchdog` is installed if the watcher fails to start.
+- Delete the database in `ops/handoffs` if embeddings become inconsistent.

--- a/clients/windows/rag/__main__.py
+++ b/clients/windows/rag/__main__.py
@@ -1,0 +1,50 @@
+"""Command line interface for Windows RAG utilities."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from . import embed_logs, retrieve
+
+
+def _path(string: str) -> Path:
+    return Path(string)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="RAG utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_embed = sub.add_parser("embed", help="Embed existing logs")
+    p_embed.add_argument("--log-dir", type=_path, default=embed_logs.DEFAULT_LOG_DIR)
+    p_embed.add_argument("--db-dir", type=_path, default=embed_logs.DEFAULT_DB_DIR)
+    p_embed.set_defaults(func=lambda a: embed_logs.main(a.log_dir, a.db_dir))
+
+    p_watch = sub.add_parser("watch", help="Watch log directory for changes")
+    p_watch.add_argument("--log-dir", type=str, default=str(embed_logs.DEFAULT_LOG_DIR))
+    p_watch.add_argument("--db-dir", type=str, default=str(embed_logs.DEFAULT_DB_DIR))
+
+    def _run_watch(a):
+        from . import watch_logs
+        watch_logs.main(a.log_dir, a.db_dir)
+
+    p_watch.set_defaults(func=_run_watch)
+
+    p_query = sub.add_parser("query", help="Retrieve similar log lines")
+    p_query.add_argument("text", help="Query text")
+    p_query.add_argument("--db-dir", type=_path, default=embed_logs.DEFAULT_DB_DIR)
+    p_query.add_argument("-k", "--top-k", type=int, default=5)
+
+    def _run_query(a):
+        results = retrieve.query(a.text, a.db_dir, a.top_k)
+        for text, score in results:
+            print(f"{score:.3f}\t{text}")
+
+    p_query.set_defaults(func=_run_query)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/clients/windows/rag/install-deps.ps1
+++ b/clients/windows/rag/install-deps.ps1
@@ -1,0 +1,9 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Set-Location -LiteralPath $PSScriptRoot
+
+if (-not (Test-Path '.venv')) {
+  python -m venv .venv
+}
+. .\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt

--- a/clients/windows/rag/retrieve.py
+++ b/clients/windows/rag/retrieve.py
@@ -1,0 +1,36 @@
+"""Simple retrieval of embedded log lines."""
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import array
+from typing import List, Tuple
+
+from . import embed_logs
+
+
+def _l2(a: List[float], b: array.array) -> float:
+    """Return the squared L2 distance between two vectors."""
+    return sum((x - y) * (x - y) for x, y in zip(a, b))
+
+
+def query(text: str, db_dir: Path = embed_logs.DEFAULT_DB_DIR, top_k: int = 5) -> List[Tuple[str, float]]:
+    """Return the *top_k* closest log lines to *text*.
+
+    If the embeddings database does not exist an empty list is returned.
+    """
+    db_path = Path(db_dir) / embed_logs.DB_FILE
+    if not db_path.exists():
+        return []
+
+    vec = embed_logs.compute_embedding(text)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT text, vector FROM embeddings").fetchall()
+
+    scored: List[Tuple[str, float]] = []
+    for row_text, blob in rows:
+        arr = array.array("f")
+        arr.frombytes(blob)
+        scored.append((row_text, _l2(vec, arr)))
+    scored.sort(key=lambda r: r[1])
+    return scored[:top_k]

--- a/clients/windows/rag/run-pipeline.ps1
+++ b/clients/windows/rag/run-pipeline.ps1
@@ -1,0 +1,7 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Set-Location -LiteralPath $PSScriptRoot
+
+. .\.venv\Scripts\Activate.ps1
+python -m clients.windows.rag embed
+python -m clients.windows.rag watch

--- a/clients/windows/rag/tests/test_embeddings.py
+++ b/clients/windows/rag/tests/test_embeddings.py
@@ -5,7 +5,7 @@ import sqlite3
 
 # Ensure repository root on path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-from clients.windows.rag import embed_logs
+from clients.windows.rag import embed_logs, retrieve
 
 
 def test_embeddings_written_and_retrievable(tmp_path):
@@ -36,3 +36,7 @@ def test_embeddings_written_and_retrievable(tmp_path):
     rows = conn.execute("SELECT text FROM embeddings ORDER BY id").fetchall()
     conn.close()
     assert [row[0] for row in rows] == ["First line", "Second line", "Third line"]
+
+    # Query retrieval returns the matching line
+    results = retrieve.query("Third line", db_dir=db_dir, top_k=1)
+    assert results and results[0][0] == "Third line"


### PR DESCRIPTION
## Summary
- add `python -m clients.windows.rag` command with embed, watch, and query subcommands
- document usage, config, troubleshooting, and `[skip local-ui]` bypass
- provide PowerShell scripts to install deps and run the pipeline

## Testing
- `pytest clients/windows/rag/tests/test_embeddings.py -q`
- `python -m clients.windows.rag --help`


------
https://chatgpt.com/codex/tasks/task_e_68ab9686c9e8832dafeedfb7f326b047