### PR TITLE
Update retrieval test for third line

### DIFF
--- a/clients/windows/rag/tests/test_embeddings.py
+++ b/clients/windows/rag/tests/test_embeddings.py
@@ -37,6 +37,5 @@ def test_embeddings_written_and_retrievable(tmp_path):
     conn.close()
     assert [row[0] for row in rows] == ["First line", "Second line", "Third line"]
 
-    # simple retrieval
-    results = retrieve.query("Second line", top_k=1, db_dir=db_dir)
-    assert results[0][3] == "Second line"
+    results = retrieve.query("Third line", top_k=1, db_dir=db_dir)
+    assert results[0][3] == "Third line"


### PR DESCRIPTION
## Summary
- Adjust retrieval test to query "Third line" and confirm correct retrieval

## Testing
- `pytest clients/windows/rag/tests/test_embeddings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ababe8f6cc832da21f8d6c411c9ec0