### PR TITLE
Add Windows bundle build script and workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,29 @@
+name: Build Windows bundle
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tools/local-ui/backend/requirements.txt
+          pip install pyinstaller
+      - name: Build bundle
+        run: |
+          python tools/local-ui/build_bundle.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: daps-windows-bundle
+          path: tools/local-ui/dist/daps_bundle.zip

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ tools/local-ui/.env
 tools/local-ui/agent-brain-context-stubs.zip
 tools/local-ui/prompt-hub-*.zip
 tools/local-ui/tools/
+tools/local-ui/dist/
 
 # --- node ---
 node_modules/

--- a/tools/local-ui/README.md
+++ b/tools/local-ui/README.md
@@ -20,6 +20,21 @@ tools\local-ui\run_backend.bat    # starts 127.0.0.1:5174
 #   cd tools\local-ui\frontend; npx vite  (http://127.0.0.1:5173)
 ```
 
+## Windows bundle
+System requirements: Windows 10 or later, 64-bit.
+
+The build script compiles the backend into a standalone `daps.exe` and assembles all
+runtime assets into a single zip file. Build locally with:
+
+```bash
+python -m pip install -r tools/local-ui/backend/requirements.txt pyinstaller
+python tools/local-ui/build_bundle.py
+```
+
+The archive will be created at `tools/local-ui/dist/daps_bundle.zip`. Extract it on
+Windows and run `daps.exe` to start the API (127.0.0.1:5174); open
+`frontend/index.html` to use the UI.
+
 ## Behavior
 - Single input, output feed, quick actions (Yes/No/Retry).
 - Agent strip, unread counts, deep link `?agent=<name>`.

--- a/tools/local-ui/build_bundle.py
+++ b/tools/local-ui/build_bundle.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+import zipfile
+
+ROOT = Path(__file__).resolve().parent
+BACKEND = ROOT / "backend"
+FRONTEND = ROOT / "frontend"
+DIST = ROOT / "dist"
+
+
+def build_backend() -> Path:
+    """Compile backend into a standalone Windows executable using PyInstaller."""
+    exe_dir = DIST / "backend"
+    exe_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "pyinstaller",
+            "--onefile",
+            "--name",
+            "daps",
+            "--distpath",
+            str(exe_dir),
+            str(BACKEND / "main.py"),
+        ],
+        check=True,
+    )
+    return exe_dir / "daps.exe"
+
+
+def assemble_bundle(exe: Path) -> Path:
+    """Collect frontend assets, executable, and launch scripts into a bundle."""
+    bundle_dir = DIST / "bundle"
+    if bundle_dir.exists():
+        shutil.rmtree(bundle_dir)
+    bundle_dir.mkdir(parents=True)
+
+    # copy frontend
+    shutil.copytree(FRONTEND, bundle_dir / "frontend")
+
+    # copy executable and helper scripts
+    shutil.copy2(exe, bundle_dir / "daps.exe")
+    for script in ["run_backend.bat", "run_backend.ps1"]:
+        src = ROOT / script
+        if src.exists():
+            shutil.copy2(src, bundle_dir / script)
+
+    # create zip archive
+    zip_path = DIST / "daps_bundle.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file in bundle_dir.rglob("*"):
+            zf.write(file, file.relative_to(bundle_dir))
+    return zip_path
+
+
+def main() -> None:
+    exe = build_backend()
+    zip_path = assemble_bundle(exe)
+    print(f"Created bundle at {zip_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to compile backend with PyInstaller and assemble Windows bundle
- add GitHub Actions workflow to build and upload Windows bundle on tagged pushes
- document Windows bundle usage and requirements for local UI
- ignore generated bundle directory

## Testing
- `python -m pip install -r tools/local-ui/backend/requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `python -m pytest tools/local-ui/backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68abaf2f9bdc832d8c07073317994f62