### PR TITLE
ci: run backend tests in windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,6 +19,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tools/local-ui/backend/requirements.txt
           pip install pyinstaller
+      - name: Run backend tests
+        run: python -m pytest tools/local-ui/backend/tests
       - name: Build bundle
         run: |
           python tools/local-ui/build_bundle.py


### PR DESCRIPTION
## Summary
- run backend tests in the Windows build workflow to ensure backend passes before bundling

## Testing
- `python -m pip install -r tools/local-ui/backend/requirements.txt pytest` *(fails: Could not connect to proxy)*
- `python -m pytest tools/local-ui/backend/tests` *(skipped: fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1aace20832db70febccb6302d97