### PR TITLE
Pin httpx and pytest versions

### DIFF
--- a/tools/local-ui/backend/requirements-dev.txt
+++ b/tools/local-ui/backend/requirements-dev.txt
@@ -1,2 +1,3 @@
-﻿pytest
-httpx
+pytest==8.2.0
+httpx==0.26.0
+


### PR DESCRIPTION
## Summary
- pin httpx in backend dev requirements
- pin pytest in backend dev requirements

## Testing
- `python -m pip install -r tools/local-ui/backend/requirements-dev.txt` *(fails: Cannot connect to proxy (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68abb1a92628832d854e722df5236edf