### PR TITLE
test: add Windows bundle smoke test

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,9 +19,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tools/local-ui/backend/requirements.txt
           pip install pyinstaller
+          pip install -r tools/local-ui/backend/requirements-dev.txt
       - name: Build bundle
         run: |
           python tools/local-ui/build_bundle.py
+      - name: Smoke test bundle
+        run: |
+          python -m pytest tools/local-ui/tests/test_bundle_smoke.py
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tools/local-ui/tests/test_bundle_smoke.py
+++ b/tools/local-ui/tests/test_bundle_smoke.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+import http.client
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows bundle test requires Windows")
+def test_bundle_smoke():
+    exe = Path(__file__).resolve().parents[1] / "dist" / "bundle" / "daps.exe"
+    if not exe.exists():
+        pytest.skip("daps.exe not found")
+
+    proc = subprocess.Popen([str(exe)], cwd=str(exe.parent))
+    try:
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            conn = http.client.HTTPConnection("127.0.0.1", 5174, timeout=1)
+            try:
+                conn.request("GET", "/health")
+                resp = conn.getresponse()
+                body = resp.read()
+                if resp.status == 200 and b"ok" in body:
+                    return
+            except OSError:
+                pass
+            finally:
+                conn.close()
+            time.sleep(0.5)
+        pytest.fail("Health endpoint did not respond in time")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- smoke test the Windows bundle by launching `daps.exe` and checking `/health`
- run the smoke test in the Windows bundle workflow

## Testing
- `python -m pytest tools/local-ui/tests/test_bundle_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abb1acf0ec832db360207bbc43eec2