### PR TITLE
Add backend dependency lock workflow and docs

### DIFF
--- a/.github/workflows/lock-backend-reqs.yml
+++ b/.github/workflows/lock-backend-reqs.yml
@@ -1,0 +1,19 @@
+name: lock-backend-reqs
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'tools/local-ui/backend/requirements.in'
+
+jobs:
+  lock-backend-reqs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: |
+          python -m pip install -U pip pip-tools
+          pip-compile --generate-hashes tools/local-ui/backend/requirements.in -o tools/local-ui/backend/requirements.lock

--- a/tools/local-ui/backend/README.md
+++ b/tools/local-ui/backend/README.md
@@ -1,0 +1,7 @@
+# Local UI Backend
+
+## Installation
+
+```bash
+pip install --require-hashes -r tools/local-ui/backend/requirements.lock
+```

--- a/tools/local-ui/backend/requirements.in
+++ b/tools/local-ui/backend/requirements.in
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+httpx
+pydantic
+orjson
+python-dotenv

--- a/tools/local-ui/backend/requirements.lock
+++ b/tools/local-ui/backend/requirements.lock
@@ -1,0 +1,7 @@
+# Placeholder lockfile; regenerate with pip-compile --generate-hashes
+fastapi==0.111.0
+uvicorn[standard]==0.30.0
+httpx==0.27.0
+pydantic==2.7.0
+orjson==3.10.3
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add requirements.in for local UI backend dependencies
- placeholder lockfile and README install instructions
- workflow to regenerate hashed lockfile via pip-compile

## Testing
- `pytest tools/local-ui/backend/tests`
- `pip install pip-tools` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abbccce0c4832d8c01b0d446bc6622