### PR TITLE
feat: allow bypass of local-ui checks in CI

### DIFF
--- a/.github/workflows/label-skip-local-ui.yml
+++ b/.github/workflows/label-skip-local-ui.yml
@@ -1,0 +1,18 @@
+name: label-skip-local-ui
+on:
+  pull_request:
+    types: [labeled, synchronize]
+permissions:
+  pull-requests: write
+  contents: read
+jobs:
+  set-skip:
+    if: contains(github.event.pull_request.labels.*.name, 'skip-local-ui-checks')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch local-ui workflow with skip
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: local-ui-pack.yml
+          inputs: '{"skip_checks":"true"}'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/local-ui-pack.yml
+++ b/.github/workflows/local-ui-pack.yml
@@ -2,15 +2,35 @@ name: local-ui-pack
 on:
   pull_request:
     branches: [ main ]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      skip_checks:
+        description: "Skip tests and build for local-ui"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
 jobs:
-  build:
-    if: >
-      !(
-        (github.event.head_commit && contains(github.event.head_commit.message, '[skip local-ui]')) ||
-        (github.event.pull_request && contains(join(github.event.pull_request.labels.*.name, ','), 'skip-local-ui'))
-      )
-    runs-on: ubuntu-latest
+  backend-tests:
+    if: ${{ inputs.skip_checks != 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - name: Run backend tests
+        working-directory: tools/local-ui
+        env:
+          PYTHONPATH: ${{ github.workspace }}\tools\local-ui
+        run: |
+          python -m pip install -r backend/requirements.lock --require-hashes
+          python -m pytest -q backend/tests
+
+  local-ui-build:
+    if: ${{ inputs.skip_checks != 'true' }}
+    runs-on: windows-latest
+    needs: backend-tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -27,5 +47,8 @@ jobs:
             tools/local-ui/run_backend.ps1 \
             tools/local-ui/.env.example \
             tools/local-ui/README.md
+        shell: bash
       - uses: actions/upload-artifact@v4
-        with: { name: prompt-hub-v0.3, path: dist/prompt-hub-v0.3.zip }
+        with:
+          name: prompt-hub-v0.3
+          path: dist/prompt-hub-v0.3.zip

--- a/tools/local-ui/README.md
+++ b/tools/local-ui/README.md
@@ -72,3 +72,7 @@ python -m pytest tools/local-ui/backend/tests
 The API tests require `fastapi` and will be skipped automatically if it is not installed.
 
 CI tick: 2025-08-24T15:54:35
+
+## CI bypass
+- Manual: Run the local-ui-pack workflow with `skip_checks=true`.
+- Label: Add `skip-local-ui-checks` to the PR to trigger a skip run.

--- a/tools/local-ui/backend/tests/test_api.py
+++ b/tools/local-ui/backend/tests/test_api.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from pathlib import Path
 import json
 
-from tools.local_ui.backend.main import app
+from backend.main import app
 client = TestClient(app)
 
 def test_health():


### PR DESCRIPTION
## Summary
- allow backend tests and build steps to be skipped via `skip_checks` workflow input
- dispatch skip run when PR labeled `skip-local-ui-checks`
- document manual and label-based CI bypass options
- limit backend test run to local-ui tests only
- fix backend test imports to use `backend.main` and set PYTHONPATH

## Testing
- ⚠️ `python -m pip install -r tools/local-ui/backend/requirements.lock --require-hashes` (ERROR: Could not find a version that satisfies the requirement fastapi==0.111.0)
- ⚠️ `PYTHONPATH=tools/local-ui python -m pytest -q tools/local-ui/backend/tests` (1 skipped)


------
https://chatgpt.com/codex/tasks/task_e_68abbef6f744832db19cf140d14934ba