### PR TITLE
ops/codex-fix-pytest-import-202508250209

### DIFF
--- a/.github/workflows/local-ui-pack.yml
+++ b/.github/workflows/local-ui-pack.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run backend tests
         working-directory: tools/local-ui
         env:
-          PYTHONPATH: ${{ github.workspace }}\tools\local-ui
+          PYTHONPATH: ${{ github.workspace }}\tools\local-ui  # ensure backend importable
         run: |
           python -m pip install -r backend/requirements.lock --require-hashes
           python -m pytest -q backend/tests

--- a/tests/test_agent_echo.py
+++ b/tests/test_agent_echo.py
@@ -3,9 +3,10 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools" / "local-ui"))
+from backend.main import app  # noqa: E402
 import backend.main as main  # noqa: E402
 
-client = TestClient(main.APP)
+client = TestClient(app)
 
 def test_agent_echo(monkeypatch):
     captured = {}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,9 +3,9 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "tools" / "local-ui"))
-from backend.main import APP  # noqa: E402
+from backend.main import app  # noqa: E402
 
-client = TestClient(APP)
+client = TestClient(app)
 
 def test_health():
     r = client.get("/health")

--- a/tools/local-ui/backend/tests/conftest.py
+++ b/tools/local-ui/backend/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure backend package is importable when tests run directly
+sys.path.append(str(Path(__file__).resolve().parents[2]))


### PR DESCRIPTION
## Summary
- ensure backend app is imported consistently in tests
- append local-ui path during backend test execution
- clarify PYTHONPATH in workflow for backend tests

## Testing
- `PYTHONPATH=tools/local-ui pytest -q tests tools/local-ui/backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68abc5071bac832da12c318b04d61686