### PR TITLE
feat: harden local-ui log watchers

### DIFF
--- a/tools/local-ui/backend/tests/test_watchers.py
+++ b/tools/local-ui/backend/tests/test_watchers.py
@@ -1,0 +1,107 @@
+import json
+import sys
+import types
+import uuid
+from pathlib import Path
+
+import time
+
+# Ensure local-ui modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from watch_logs import _request_with_retry, _wait_for_stable, MAX_RETRIES  # noqa: E402
+from embed_logs import _post_with_retry  # noqa: E402
+
+
+def install_httpx_stub(monkeypatch, *, mode: str):
+    """Install a minimal httpx stub into sys.modules."""
+    class HTTPStatusError(Exception):
+        def __init__(self, message="", response=None):
+            super().__init__(message)
+            self.response = response
+
+    class ConnectError(Exception):
+        pass
+
+    class TimeoutException(Exception):
+        pass
+
+    class DummyResponse:
+        def __init__(self, status_code=500, json_data=None):
+            self.status_code = status_code
+            self._json = json_data or {}
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise HTTPStatusError(response=self)
+
+        def json(self):
+            return self._json
+
+    calls = {"count": 0}
+    
+    def fake_request(method, url, timeout=None):
+        calls["count"] += 1
+        if mode == "connect":
+            raise ConnectError("boom")
+        resp = DummyResponse(500)
+        resp.raise_for_status()
+        return resp
+
+    def fake_post(url, json=None, timeout=None):
+        calls["count"] += 1
+        if mode == "connect":
+            raise ConnectError("boom")
+        resp = DummyResponse(500)
+        resp.raise_for_status()
+        return resp
+
+    stub = types.SimpleNamespace(
+        ConnectError=ConnectError,
+        HTTPStatusError=HTTPStatusError,
+        TimeoutException=TimeoutException,
+        Timeout=lambda *a, **k: None,
+        request=fake_request,
+        post=fake_post,
+    )
+    monkeypatch.setitem(sys.modules, "httpx", stub)
+    return calls
+
+
+def test_request_with_retry_http_error(monkeypatch, capsys):
+    calls = install_httpx_stub(monkeypatch, mode="status")
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=0))
+    result = _request_with_retry("get", "http://example", path=Path("f"))
+    assert result == {"kind": "error", "code": 500}
+    assert calls["count"] == MAX_RETRIES
+    log = json.loads(capsys.readouterr().out.splitlines()[0])
+    assert log["path"] == "f"
+    assert log["retry"] == 1
+
+
+def test_post_with_retry_connect_error(monkeypatch, capsys):
+    calls = install_httpx_stub(monkeypatch, mode="connect")
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID(int=0))
+    result = _post_with_retry({"text": "hi"}, path=Path("f"))
+    assert result == {"kind": "error", "code": "connect"}
+    assert calls["count"] == MAX_RETRIES
+    log = json.loads(capsys.readouterr().out.splitlines()[0])
+    assert log["retry"] == 1 and log["path"] == "f"
+
+
+def test_wait_for_stable(monkeypatch):
+    sizes = [10, 20, 20, 20, 20]
+
+    class Stat:
+        def __init__(self, size):
+            self.st_size = size
+
+    def fake_stat(self):
+        return Stat(sizes.pop(0))
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    assert _wait_for_stable(Path("dummy"), intervals=3, delay=0.0)

--- a/tools/local-ui/db.py
+++ b/tools/local-ui/db.py
@@ -1,0 +1,133 @@
+"""Simple SQLite/FAISS helpers for log embeddings."""
+
+from __future__ import annotations
+
+import array
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import faiss  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    faiss = None
+    np = None
+
+try:  # pragma: no cover - optional dependency
+    import pgvector  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    pgvector = None
+
+SCHEMA = """CREATE TABLE IF NOT EXISTS embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT,
+    line INTEGER,
+    text TEXT,
+    vector BLOB,
+    vec VECTOR(8)
+);"""
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    """Return a connection and ensure schema exists."""
+    conn = sqlite3.connect(db_path)
+    if pgvector is not None:  # pragma: no cover - optional branch
+        try:
+            conn.enable_load_extension(True)
+            pgvector.load(conn)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    conn.execute(SCHEMA)
+    return conn
+
+
+def load_index(index_path: Path, dim: int):
+    """Return a FAISS index if the library is available."""
+    if faiss is None:
+        return None
+    if index_path.exists():
+        return faiss.read_index(str(index_path))
+    return faiss.IndexFlatL2(dim)
+
+
+def save_index(index, index_path: Path) -> None:
+    """Persist *index* to *index_path* if possible."""  # pragma: no cover - simple wrapper
+    if faiss is None or index is None:
+        return
+    faiss.write_index(index, str(index_path))
+
+
+def add_embedding(
+    conn: sqlite3.Connection,
+    index,
+    source: str,
+    line: int,
+    text: str,
+    vector: Iterable[float],
+) -> int:
+    """Insert *vector* for *text* into the database and index."""
+    vec_list = list(vector)
+    arr = array.array("f", vec_list)
+    vec_val = pgvector.to_db(vec_list) if pgvector is not None else None
+    cur = conn.execute(
+        "INSERT INTO embeddings (source, line, text, vector, vec) VALUES (?, ?, ?, ?, ?)",
+        (source, line, text, arr.tobytes(), vec_val),
+    )
+    rowid = cur.lastrowid
+    if index is not None and np is not None:  # pragma: no cover - optional branch
+        vec_np = np.asarray(vec_list, dtype="float32")
+        ids = np.asarray([rowid], dtype="int64")
+        index.add_with_ids(vec_np.reshape(1, -1), ids)
+    conn.commit()
+    return rowid
+
+
+def fetch_all(conn: sqlite3.Connection) -> Iterator[tuple[int, str, int, str, bytes]]:
+    """Yield all rows from the embeddings table."""
+    cursor = conn.execute(
+        "SELECT id, source, line, text, vector FROM embeddings ORDER BY id"
+    )
+    yield from cursor
+
+
+def search(
+    conn: sqlite3.Connection,
+    index,
+    vector: Sequence[float],
+    top_k: int,
+) -> list[tuple[int, str, int, str, float]]:
+    """Return the closest *top_k* rows for *vector*.
+
+    Results are ordered by increasing squared L2 distance. If a FAISS ``index``
+    is provided and the library is available, it is queried directly. Otherwise
+    all rows are loaded via :func:`fetch_all` and distances computed in pure
+    Python.
+    """
+
+    q_list = list(vector)
+    results: list[tuple[int, str, int, str, float]] = []
+
+    if index is not None and faiss is not None and np is not None:  # pragma: no cover
+        q_np = np.asarray(q_list, dtype="float32").reshape(1, -1)
+        distances, ids = index.search(q_np, top_k)
+        for dist, idx in zip(distances[0], ids[0]):
+            if idx == -1:
+                continue
+            row = conn.execute(
+                "SELECT id, source, line, text FROM embeddings WHERE id = ?",
+                (int(idx),),
+            ).fetchone()
+            if row:
+                results.append((*row, float(dist)))
+        return results
+
+    # Fallback: compute distance in Python
+    for row_id, source, line, text, blob in fetch_all(conn):
+        vec = array.array("f")
+        vec.frombytes(blob)
+        dist = sum((a - b) ** 2 for a, b in zip(q_list, vec))
+        results.append((row_id, source, line, text, float(dist)))
+    results.sort(key=lambda x: x[4])
+    return results[:top_k]
+

--- a/tools/local-ui/embed_logs.py
+++ b/tools/local-ui/embed_logs.py
@@ -1,0 +1,143 @@
+"""Embed log files and persist vectors for retrieval."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sqlite3
+from pathlib import Path
+from typing import Optional
+import time
+import uuid
+
+import db
+
+LOG_DIR = Path("ops/handoffs/logs")
+DB_PATH = LOG_DIR / "embeddings.db"
+VECTOR_DIM = 8
+
+EMBED_URL = "http://localhost:8000/embed"
+MAX_RETRIES = 5
+MAX_BACKOFF = 30
+COOLDOWN = 60
+
+
+def write_embedding_to_db(path: Path) -> None:
+    """Persist embedding metadata for *path* in a SQLite database."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS embeddings (file TEXT UNIQUE)"
+        )
+        conn.execute("INSERT OR REPLACE INTO embeddings(file) VALUES (?)", (str(path),))
+
+
+DEFAULT_LOG_DIR = Path("ops/handoffs/logs")
+DEFAULT_DB_DIR = Path("ops/handoffs")
+DB_FILE = "embeddings.db"
+INDEX_FILE = "embeddings.faiss"
+
+
+def embed_file(path: Path) -> None:
+    """Run ``ollama embed`` on ``path`` if available."""
+    try:
+        subprocess.run(["ollama", "embed", str(path)], check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        print(f"Embedding failed for {path}: {exc}")
+        return
+
+    try:
+        write_embedding_to_db(path)
+    except sqlite3.DatabaseError as exc:
+        print(f"Failed to write embedding for {path}: {exc}")
+
+
+def _post_with_retry(data: dict, *, path: Path | None = None) -> dict:
+    """POST *data* to the embed endpoint with retries.
+
+    Returns a structured result: ``{"kind": "ok", "json": {...}}`` on success or
+    ``{"kind": "error", "code": <code>}`` on failure.
+    """
+
+    import httpx  # imported lazily for easier testing
+
+    event_id = uuid.uuid4().hex
+    delay = 1.0
+    timeout = httpx.Timeout(10.0, connect=10.0)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            r = httpx.post(EMBED_URL, json=data, timeout=timeout)
+            r.raise_for_status()
+            return {"kind": "ok", "json": r.json()}
+        except httpx.ConnectError:
+            code = "connect"
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+        else:  # pragma: no cover - defensive
+            code = "unknown"
+        log = {
+            "event": "embed_error",
+            "id": event_id,
+            "path": str(path) if path else None,
+            "retry": attempt,
+            "code": code,
+        }
+        print(json.dumps(log))
+        if attempt == MAX_RETRIES:
+            print(json.dumps({"event": "circuit_breaker", "id": event_id}))
+            time.sleep(COOLDOWN)
+            break
+        time.sleep(min(delay, MAX_BACKOFF))
+        delay *= 2
+    return {"kind": "error", "code": code}
+
+
+def compute_embedding(text: str, dim: int = VECTOR_DIM) -> list[float]:
+    """Return a deterministic embedding vector for *text*."""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return [int.from_bytes(digest[i : i + 4], "little") / 2 ** 32 for i in range(0, dim * 4, 4)]
+
+
+def process_file(
+    path: Path,
+    conn,
+    index,
+    index_path: Path,
+) -> Optional[object]:
+    """Embed new lines from *path* and store them."""
+    existing = conn.execute(
+        "SELECT MAX(line) FROM embeddings WHERE source = ?", (str(path),)
+    ).fetchone()[0]
+    processed = existing or 0
+    with path.open("r", encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            if lineno <= processed:
+                continue
+            text = line.strip()
+            if not text:
+                continue
+            vector = compute_embedding(text)
+            _post_with_retry({"text": text}, path=path)
+            if index is None:
+                index = db.load_index(index_path, VECTOR_DIM)
+            db.add_embedding(conn, index, str(path), lineno, text, vector)
+    return index
+
+
+def main(
+    log_dir: Path = DEFAULT_LOG_DIR,
+    db_dir: Path = DEFAULT_DB_DIR,
+) -> None:
+    db_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / DB_FILE
+    index_path = db_dir / INDEX_FILE
+    conn = db.connect(db_path)
+    index = None
+    for log in log_dir.glob("*.log"):
+        index = process_file(log, conn, index, index_path)
+    db.save_index(index, index_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/local-ui/watch_logs.py
+++ b/tools/local-ui/watch_logs.py
@@ -1,0 +1,175 @@
+"""Watch handoff log files and update vector index."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+except ModuleNotFoundError:  # pragma: no cover - import guard
+    Observer = None  # type: ignore[assignment]
+
+    class FileSystemEventHandler:  # type: ignore
+        pass
+
+import db
+from embed_logs import (
+    DEFAULT_DB_DIR,
+    DEFAULT_LOG_DIR,
+    INDEX_FILE,
+    DB_FILE,
+    process_file,
+)
+
+MAX_RETRIES = 5
+MAX_BACKOFF = 30
+COOLDOWN = 60
+
+
+def _request_with_retry(method: str, url: str, *, path: Path | None = None) -> dict:
+    """Send an HTTP request with retries and return a structured result."""
+
+    import httpx  # imported lazily for easier testing
+
+    event_id = uuid.uuid4().hex
+    delay = 1.0
+    timeout = httpx.Timeout(10.0, connect=10.0)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            r = httpx.request(method, url, timeout=timeout)
+            r.raise_for_status()
+            return {"kind": "ok"}
+        except httpx.ConnectError:
+            code = "connect"
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+        except httpx.TimeoutException:
+            code = "timeout"
+        log = {
+            "event": "request_error",
+            "id": event_id,
+            "path": str(path) if path else None,
+            "retry": attempt,
+            "code": code,
+        }
+        print(json.dumps(log))
+        if attempt == MAX_RETRIES:
+            print(json.dumps({"event": "circuit_breaker", "id": event_id}))
+            time.sleep(COOLDOWN)
+            break
+        time.sleep(min(delay, MAX_BACKOFF))
+        delay *= 2
+    return {"kind": "error", "code": code}
+
+
+def _wait_for_stable(path: Path, intervals: int = 3, delay: float = 1.0) -> bool:
+    prev = -1
+    stable = 0
+    start = time.time()
+    while time.time() - start < 60:
+        size = path.stat().st_size if path.exists() else -1
+        if size == prev:
+            stable += 1
+            if stable >= intervals:
+                return True
+        else:
+            stable = 0
+            prev = size
+        time.sleep(delay)
+    return False
+
+class LogHandler(FileSystemEventHandler):
+    """Append new log lines to the transcript and vector index."""
+
+    def __init__(self, conn=None, index=None, index_path: Path | None = None):
+        self.conn = conn
+        self.index = index
+        self.index_path = index_path or Path(INDEX_FILE)
+
+    def on_modified(self, event):  # pragma: no cover - callback
+        if not event.is_directory:
+            path = Path(event.src_path)
+            event_id = uuid.uuid4().hex
+            print(json.dumps({"event": "modified", "id": event_id, "path": str(path)}))
+            if not _wait_for_stable(path):
+                return
+            result = _request_with_retry(
+                "get", "http://localhost:8000/health", path=path
+            )
+            if result.get("kind") == "error":
+                return
+            try:
+                self.index = process_file(
+                    path, self.conn, self.index, self.index_path
+                )
+                db.save_index(self.index, self.index_path)
+            except FileNotFoundError as exc:
+                print(
+                    json.dumps(
+                        {
+                            "event": "file_missing",
+                            "id": event_id,
+                            "path": str(path),
+                            "code": str(exc),
+                        }
+                    )
+                )
+            except sqlite3.DatabaseError as exc:
+                log = {
+                    "event": "db_error",
+                    "id": event_id,
+                    "path": str(path),
+                    "code": str(exc),
+                }
+                print(json.dumps(log))
+                try:
+                    self.index = process_file(
+                        path, self.conn, self.index, self.index_path
+                    )
+                    db.save_index(self.index, self.index_path)
+                except Exception as retry_exc:
+                    print(
+                        json.dumps(
+                            {
+                                "event": "retry_failed",
+                                "id": event_id,
+                                "path": str(path),
+                                "code": str(retry_exc),
+                            }
+                        )
+                    )
+
+
+def main(log_dir: str = str(DEFAULT_LOG_DIR), db_dir: str = str(DEFAULT_DB_DIR)) -> None:
+    """Monitor *log_dir* for changes."""
+    directory = Path(log_dir)
+    if not directory.exists():
+        print(f"Log directory {directory} does not exist")
+        return
+
+    db_path = Path(db_dir) / DB_FILE
+    index_path = Path(db_dir) / INDEX_FILE
+    conn = db.connect(db_path)
+    index = db.load_index(index_path, 8)
+
+    handler = LogHandler(conn, index, index_path)
+    observer = Observer()
+    observer.schedule(handler, str(directory), recursive=False)
+    observer.start()
+    print(f"Watching {directory} for updates...")
+
+    try:  # pragma: no cover - long running loop
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add structured retry logic and circuit breaker to local-ui watchers
- capture errors from embed API calls with structured responses
- test watcher resilience and file stability handling

## Testing
- `pytest tools/local-ui/backend/tests/test_watchers.py`
- `pytest tools/local-ui/backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi httpx` *(fails: Could not find a version that satisfies the requirement fastapi)*

## Branch
ops/codex-harden-watchers-20250825T051624


------
https://chatgpt.com/codex/tasks/task_e_68abec80db48832da5a5ba09f7e61c97