### PR TITLE
feat: allow docs/hotfix to bypass local UI pack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+- 
+
+## Testing
+- [ ] `npm test`
+- [ ] `pytest`
+
+## Local UI Bypass
+Only documentation changes or preapproved hotfixes may bypass the local UI pack.
+- [ ] This PR is docs-only or an approved hotfix.
+- [ ] I added the `ci-bypass-localui` label if bypassing.

--- a/.github/workflows/label-skip-local-ui.yml
+++ b/.github/workflows/label-skip-local-ui.yml
@@ -7,12 +7,12 @@ permissions:
   contents: read
 jobs:
   set-skip:
-    if: contains(github.event.pull_request.labels.*.name, 'skip-local-ui-checks')
+    if: contains(github.event.pull_request.labels.*.name, 'ci-bypass-localui')
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch local-ui workflow with skip
+      - name: Dispatch local-ui workflow with bypass
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: local-ui-pack.yml
-          inputs: '{"skip_checks":"true"}'
+          inputs: '{"allow_bypass":"true"}'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/local-ui-pack.yml
+++ b/.github/workflows/local-ui-pack.yml
@@ -4,8 +4,8 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
-      skip_checks:
-        description: "Skip tests and build for local-ui"
+      allow_bypass:
+        description: "Allow ci-bypass-localui label to skip UI pack"
         required: false
         default: "false"
         type: choice
@@ -13,7 +13,6 @@ on:
 
 jobs:
   backend-tests:
-    if: ${{ inputs.skip_checks != 'true' }}
     runs-on: windows-latest
     defaults:
       run:
@@ -31,9 +30,15 @@ jobs:
       - name: Run backend tests
         working-directory: tools/local-ui
         run: pytest -q backend/tests
+      - name: Record bypass
+        if: ${{ github.event_name == 'pull_request' && inputs.allow_bypass == 'true' && contains(github.event.pull_request.labels.*.name, 'ci-bypass-localui') && (contains(github.event.pull_request.labels.*.name, 'Docs') || contains(github.event.pull_request.labels.*.name, 'docs-only') || contains(github.event.pull_request.labels.*.name, 'Hotfix') || contains(github.event.pull_request.labels.*.name, 'hotfix')) }}
+        run: |
+          echo "local-ui-pack bypassed by ${{ github.actor }}" >> $env:GITHUB_STEP_SUMMARY
+          echo "labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}" >> $env:GITHUB_STEP_SUMMARY
+          echo "::warning::local-ui-pack bypassed by ${{ github.actor }}"
 
   local-ui-build:
-    if: ${{ inputs.skip_checks != 'true' }}
+    if: ${{ !(github.event_name == 'pull_request' && inputs.allow_bypass == 'true' && contains(github.event.pull_request.labels.*.name, 'ci-bypass-localui') && (contains(github.event.pull_request.labels.*.name, 'Docs') || contains(github.event.pull_request.labels.*.name, 'docs-only') || contains(github.event.pull_request.labels.*.name, 'Hotfix') || contains(github.event.pull_request.labels.*.name, 'hotfix'))) }}
     runs-on: windows-latest
     needs: backend-tests
     defaults:

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,14 @@
+# Branch Protection Bypass Policy
+
+The `local-ui-pack` workflow normally builds UI artifacts for every pull request. In limited cases, this job may be bypassed while backend tests continue to run.
+
+### When a bypass is allowed
+- The pull request is labeled `ci-bypass-localui`.
+- The change is documentation-only or has a preapproved hotfix label.
+
+### Effect of bypass
+- Backend tests still execute.
+- The `local-ui-build` job is marked as skipped with an annotation.
+- The workflow summary records the actor and labels involved.
+
+Misuse of the bypass may result in reverted changes.


### PR DESCRIPTION
## Summary
- add `allow_bypass` flag to local-ui-pack workflow and honor `ci-bypass-localui`
- document bypass policy and add PR template checklist

## Testing
- `npm test` *(fails: ModuleNotFoundError: httpx, fastapi)*
- `pytest` *(fails: ModuleNotFoundError: httpx, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68abec850168832db52cfd55be79a62a