### PR TITLE
feat: add skip_pack input for local-ui-pack

### DIFF
--- a/.github/workflows/local-ui-pack.yml
+++ b/.github/workflows/local-ui-pack.yml
@@ -3,9 +3,18 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    # Inputs allow selectively skipping backend tests or packaging.
+    # - skip_checks: Skip backend tests
+    # - skip_pack: Skip packaging the local-ui artifact
     inputs:
       skip_checks:
-        description: "Skip tests and build for local-ui"
+        description: "Skip backend tests for local-ui"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      skip_pack:
+        description: "Skip packaging the local-ui artifact"
         required: false
         default: "false"
         type: choice
@@ -33,7 +42,8 @@ jobs:
         run: pytest -q backend/tests
 
   local-ui-build:
-    if: ${{ inputs.skip_checks != 'true' }}
+    # Run build unless skip_pack is explicitly true
+    if: ${{ inputs.skip_pack != 'true' }}
     runs-on: windows-latest
     needs: backend-tests
     defaults:


### PR DESCRIPTION
## Summary
- allow local-ui pack workflow to skip artifact packaging via new `skip_pack` input
- document workflow inputs and gate packaging job on `skip_pack`

## Testing
- `yamllint .github/workflows/local-ui-pack.yml` *(fails: command not found and package install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4fc1804832da62f9df10a2b018f