### PR TITLE
chore: dispatch local-ui pack with skip_pack

### DIFF
--- a/.github/workflows/label-skip-local-ui.yml
+++ b/.github/workflows/label-skip-local-ui.yml
@@ -7,12 +7,12 @@ permissions:
   contents: read
 jobs:
   set-skip:
-    if: contains(github.event.pull_request.labels.*.name, 'skip-local-ui-checks')
+    if: contains(github.event.pull_request.labels.*.name, 'skip-local-ui-pack')
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch local-ui workflow with skip
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: local-ui-pack.yml
-          inputs: '{"skip_checks":"true"}'
+          inputs: '{"skip_pack":"true"}'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/local-ui/README.md
+++ b/tools/local-ui/README.md
@@ -74,5 +74,5 @@ The API tests require `fastapi` and will be skipped automatically if it is not i
 CI tick: 2025-08-24T15:54:35
 
 ## CI bypass
-- Manual: Run the local-ui-pack workflow with `skip_checks=true`.
-- Label: Add `skip-local-ui-checks` to the PR to trigger a skip run.
+- Manual: Run the local-ui-pack workflow with `skip_pack=true`.
+- Label: Add `skip-local-ui-pack` to the PR to trigger a skip run.


### PR DESCRIPTION
## Summary
- trigger local-ui pack workflow using `skip_pack` input
- document `skip-local-ui-pack` label for bypassing local UI pack

## Testing
- `npm test` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68abf4fe00a8832dbbfdf721b8f6c3d4